### PR TITLE
Adding launch_template_id as a keeper of the random_pet

### DIFF
--- a/modules/node_groups/random.tf
+++ b/modules/node_groups/random.tf
@@ -17,6 +17,7 @@ resource "random_pet" "node_groups" {
     ))
     subnet_ids      = join("|", each.value["subnets"])
     node_group_name = join("-", [var.cluster_name, each.key])
+    launch_template = lookup(each.value, "launch_template_id", null)
   }
 
   depends_on = [var.ng_depends_on]


### PR DESCRIPTION
# PR o'clock

## Description

Without making the random pet depend on launch_template_id, a change on the template would make terraform try to create a new node group without changing names which creates this error:
```
module.terraform-aws-modules.module.node_groups.aws_eks_node_group.workers["default"]: Creating...

Error: error creating EKS Node Group (cluster_name:cluster_name-default-concise-guppy): ResourceInUseException: NodeGroup already exists with name cluster_name-default-concise-guppy and cluster name cluster_name
{
  RespMetadata: {
    StatusCode: 409,
    RequestID: "3d454632-166b-4159-a245-f6f16bcc4aa5"
  },
  ClusterName: "cluster_name",
  Message_: "NodeGroup already exists with name cluster_name-default-concise-guppy and cluster name cluster_name",
  NodegroupName: "cluster_name-default-concise-guppy"
}
```

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
